### PR TITLE
Remove AsynchronousType

### DIFF
--- a/Form/WidgetRichListType.php
+++ b/Form/WidgetRichListType.php
@@ -52,14 +52,6 @@ class WidgetRichListType extends WidgetListingType
                 'data-flag' => 'v-quantum-name',
             ],
         ]);
-
-        $builder->add('asynchronous', AsynchronousType::class, [
-            'label'    => 'victoire.widget.type.asynchronous.label',
-            'required' => false,
-            'attr'     => [
-                'class' => 'vic-col-xs-12',
-            ],
-        ]);
     }
 
     /**


### PR DESCRIPTION
AsynchronousType has been removed in Victoire 2.3.29: https://github.com/Victoire/victoire/releases/tag/2.3.29
QuantumType should be imported from parent form type